### PR TITLE
Added subsites support

### DIFF
--- a/code/extensions/MockDataObject.php
+++ b/code/extensions/MockDataObject.php
@@ -176,6 +176,9 @@ class MockDataObject extends DataExtension {
 					}
 				}
 			}
+			else if ($className == "Subsite"){
+				continue;
+			}
 			else {
 				$random_record = DataList::create($className)->sort("RAND()")->first();
 				if(!$random_record && !$sitetree) {


### PR DESCRIPTION
Fixes an issue where mock pages were linked to a random subsite rather than the one they were created under in the CMS
