### PR TITLE
NEW Allow blacklisting DB fields from mocking

### DIFF
--- a/_config/mock_dataobjects.yml
+++ b/_config/mock_dataobjects.yml
@@ -19,6 +19,9 @@ MockDataObject:
     only_empty: true
   relation_create_limit: 5
 
+Member:
+  mock_blacklist:
+    - PasswordEncryption
 SiteTree:
   extensions:
     - MockDataSiteTree

--- a/code/extensions/MockDataObject.php
+++ b/code/extensions/MockDataObject.php
@@ -18,7 +18,7 @@ class MockDataObject extends DataExtension
      */
     protected $fakeInstance;
 
-
+    private static $mock_blacklist = array();
 
     /**
      * An accessor to get all of the stock files that ship with the package
@@ -152,6 +152,7 @@ class MockDataObject extends DataExtension
 
         // Anything that is a core SiteTree field, e.g. "URLSegment", "ShowInMenus", "ParentID",  we don't care about.
         $omit = Injector::inst()->get("SiteTree")->db();
+        $omit = array_merge($omit, $this->owner->config()->mock_blacklist);
 
         // Except these two.
         unset($omit['Title']);


### PR DESCRIPTION
It's currently not possible to add mock members because the `PasswordEncryption` field is filled with Lorem text instead of a valid password encryptor.

This change adds the ability to add per class blacklists to dataobjects and adds the `PasswordEncryption` field to the default blacklist for members - allowing them to work out of the box